### PR TITLE
レスポンシブ対応のレイアウト整備 (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ wheels/
 
 # Virtual environments
 .venv
+
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `main.py`: Dash app entrypoint; contains layout, Japanese UI copy, and `simulate_gacha` / `update_simulation` logic. Add new callbacks here until a refactor splits modules.
+- `pyproject.toml` and `uv.lock`: Dependency sources of truth. `requirements.txt` is generated; avoid manual edits.
+- `README.md`: User-facing overview and setup notes. Update when behavior, commands, or UI text change.
+- Tests are not yet present. If you add them, prefer `tests/` with `pytest` and keep fixtures small and deterministic.
+
+## Build, Test, and Development Commands
+- Install deps: `uv sync` (preferred) or `uv pip install -r requirements.txt`.
+- Run locally: `uv run main.py` (respects `PORT`, defaults to 8050).
+- Prod-like serve: `uv run gunicorn main:app.server --bind 0.0.0.0:8050 --workers 2`.
+- Update pinned deps after changes: `uv pip compile pyproject.toml -o requirements.txt`.
+
+## Coding Style & Naming Conventions
+- Target Python 3.14; keep the existing 2-space indentation to minimize diffs.
+- Use `snake_case` for functions and variables; ユーザー向け文言と貢献者向けの説明は必ず日本語で統一し、既存UIのトーンを維持する（内部メモは出力に混ぜない）。
+- Prefer small, pure helpers for probability math; keep Dash callbacks declarative and free of side effects.
+- Add concise docstrings for new public functions and validations。
+
+## Testing Guidelines
+- Manual smoke for now: `uv run main.py` and verify sliders/inputs update the histogram and stats at `http://127.0.0.1:8050/` without errors.
+- Exercise edge cases (very small/large probabilities, invalid inputs) to confirm error handling and clipping logic.
+- Future tests: name files `test_*.py`, seed randomness where needed, and avoid network or time-dependent behavior.
+
+## Commit & Pull Request Guidelines
+- 作業を始めるときは必ず main から作業ブランチを切る（例: `git checkout -b feature/responsive`）；直接 main にはコミットしない。
+- Commit messages: clear, imperative verbs (e.g., `Tighten input validation`); no strict convention detected.
+- PRs: include intent, key changes, run steps (`uv run main.py`), and screenshots/gifs for UI tweaks.
+- Link related issues and flag risk areas (probability math, layout changes); note follow-ups explicitly.
+
+## Security & Configuration Tips
+- The app reads `PORT`; default is 8050. Document any new env vars you introduce.
+- Keep secrets out of the repo; configure them via environment variables or deployment tooling.
+- After dependency changes, run `uv lock` or `uv sync` to keep `uv.lock` and `requirements.txt` aligned for reproducible deploys.

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,174 @@
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --radius: 10px;
+  --border: #e5e7eb;
+  --text: #0f172a;
+  --muted: #475569;
+  --bg: #f8fafc;
+  --card-bg: #ffffff;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "system-ui", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.app-shell {
+  max-width: 1120px;
+  padding: var(--space-5) var(--space-4);
+  margin: 0 auto;
+}
+
+.section {
+  margin-bottom: var(--space-6);
+}
+
+.page-title {
+  margin: 0 0 var(--space-2);
+  font-size: 1.9rem;
+  line-height: 1.3;
+}
+
+.page-lead {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.control-card,
+.stats-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  box-shadow: var(--shadow);
+}
+
+.section-title {
+  margin: 0 0 var(--space-3);
+}
+
+.control-field {
+  margin-bottom: var(--space-4);
+}
+
+.control-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.control-input {
+  width: 100%;
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.control-slider {
+  padding: 0 var(--space-1);
+}
+
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-4);
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 700;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+  width: 100%;
+}
+
+.primary-button:hover {
+  background: #1d4ed8;
+}
+
+.primary-button:active {
+  transform: translateY(1px);
+}
+
+.error-msg {
+  color: #b91c1c;
+  margin-top: var(--space-2);
+  min-height: 1.2rem;
+}
+
+.stats-output p {
+  margin: 0 0 var(--space-2);
+  line-height: 1.6;
+}
+
+.graph-section {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  box-shadow: var(--shadow);
+}
+
+.histogram-graph {
+  width: 100%;
+  height: 320px;
+}
+
+@media (min-width: 600px) {
+  .histogram-graph {
+    height: 360px;
+  }
+}
+
+@media (min-width: 768px) {
+  .app-shell {
+    padding: var(--space-6) var(--space-5);
+  }
+
+  .layout-grid {
+    grid-template-columns: 1.05fr 0.95fr;
+    gap: var(--space-5);
+  }
+
+  .primary-button {
+    width: auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  .app-shell {
+    max-width: 1240px;
+  }
+
+  .layout-grid {
+    grid-template-columns: 1.15fr 0.85fr;
+  }
+
+  .histogram-graph {
+    height: 420px;
+  }
+}

--- a/main.py
+++ b/main.py
@@ -17,66 +17,94 @@ app = Dash(__name__)
 app.title = "ガチャ期待値＆爆死シミュレーター"
 
 app.layout = html.Div(
-  style={"maxWidth": "800px", "margin": "auto", "fontFamily": "system-ui"},
+  className="app-shell",
   children=[
-    html.H1("ガチャ期待値＆爆死シミュレーター"),
-    html.P("SSRの排出率や課金額を変えて、爆死リスクを可視化してみよう。"),
-
-    html.Hr(),
+    html.Div(
+      className="section header-section",
+      children=[
+        html.H1("ガチャ期待値＆爆死シミュレーター", className="page-title"),
+        html.P("SSRの排出率や課金額を変えて、爆死リスクを可視化してみよう。", className="page-lead"),
+      ]
+    ),
 
     html.Div(
-      style={"display": "flex", "gap": "2rem", "flexWrap": "wrap"},
+      className="section",
       children=[
         html.Div(
-          style={"flex": "1 1 250px"},
+          className="layout-grid",
           children=[
-            html.Label("SSR排出率 (%)"),
-            dcc.Slider(
-              id="prob-slider",
-              min=0.1,
-              max=10,
-              step=0.1,
-              value=3,
-              marks={0.1: "0.1", 1: "1", 3: "3", 5: "5", 10: "10"},
-              tooltip={"placement": "bottom", "always_visible": True},
+            html.Div(
+              className="control-card",
+              children=[
+                html.Div(
+                  className="control-field",
+                  children=[
+                    html.Label("SSR排出率 (%)", className="control-label"),
+                    dcc.Slider(
+                      id="prob-slider",
+                      min=0.1,
+                      max=10,
+                      step=0.1,
+                      value=3,
+                      marks={0.1: "0.1", 1: "1", 3: "3", 5: "5", 10: "10"},
+                      tooltip={"placement": "bottom", "always_visible": True},
+                      className="control-slider",
+                    ),
+                  ]
+                ),
+                html.Div(
+                  className="control-field",
+                  children=[
+                    html.Label("1回あたりの課金額 (円)", className="control-label"),
+                    dcc.Input(id="cost-input", type="number", value=300, min=1, step=10, className="control-input"),
+                  ]
+                ),
+                html.Div(
+                  className="control-field",
+                  children=[
+                    html.Label("シミュレーション回数", className="control-label"),
+                    dcc.Slider(
+                      id="nsims-slider",
+                      min=1000,
+                      max=50000,
+                      step=1000,
+                      value=10000,
+                      marks={1000: "1k", 10000: "10k", 50000: "50k"},
+                      tooltip={"placement": "bottom", "always_visible": True},
+                      className="control-slider",
+                    ),
+                  ]
+                ),
+                html.Div(
+                  className="control-field",
+                  children=[
+                    html.Label("爆死とみなす上限回数", className="control-label"),
+                    dcc.Input(id="hardcap-input", type="number", value=200, min=1, step=10, className="control-input"),
+                  ]
+                ),
+                html.Button("シミュレーション実行", id="run-button", className="primary-button"),
+                html.Div(id="error-msg", className="error-msg"),
+              ]
             ),
-            html.Br(),
-
-            html.Label("1回あたりの課金額 (円)"),
-            dcc.Input(id="cost-input", type="number", value=300, min=1, step=10, style={"width": "100%"}),
-            html.Br(), html.Br(),
-
-            html.Label("シミュレーション回数"),
-            dcc.Slider(
-              id="nsims-slider",
-              min=1000,
-              max=50000,
-              step=1000,
-              value=10000,
-              marks={1000: "1k", 10000: "10k", 50000: "50k"},
-              tooltip={"placement": "bottom", "always_visible": True},
-            ),
-            html.Br(),
-
-            html.Label("爆死とみなす上限回数"),
-            dcc.Input( id="hardcap-input", type="number", value=200, min=1, step=10, style={"width": "100%"} ),
-            html.Br(),
-            html.Br(),
-
-            html.Button("シミュレーション実行", id="run-button"),
-            html.Div(id="error-msg", style={"color": "red", "marginTop": "0.5rem"}),
+            html.Div(
+              className="stats-card",
+              children=[
+                html.H3("統計まとめ", className="section-title"),
+                html.Div(id="stats-output", className="stats-output")
+              ]
+            )
           ]
-        ),
-        html.Div(
-          style={"flex": "1 1 300px"},
-          children=[html.H3("統計まとめ"), html.Div(id="stats-output")]
         )
       ]
     ),
 
-    html.Hr(),
-    html.H3("SSRが初めて出るまでに必要な回数の分布"),
-    dcc.Graph(id="hist-graph"),
+    html.Div(
+      className="section graph-section",
+      children=[
+        html.H3("SSRが初めて出るまでに必要な回数の分布", className="section-title"),
+        dcc.Graph(id="hist-graph", className="histogram-graph"),
+      ]
+    ),
   ]
 )
 


### PR DESCRIPTION
## 概要
- #2 の対応でUIをレスポンシブにする土台を追加。
- 既存レイアウトをクラス付与しCSS制御しやすく整理。

## 変更点
- `main.py`: セクション化とクラス名付与、フォーム/統計/グラフの構造をCSS前提に整理。
- `assets/style.css`: 320px〜縦積み、768px〜2カラム、1024px〜余裕のブレークポイントレイアウト。余白/フォント/ボタン/グラフ高さを調整。
- `AGENTS.md`: 作業ブランチ必須の運用を追記。
- `.gitignore`: `.env` を追加。

## 動作確認
- 未実施（必要なら `uv run main.py` で320/768/1440px相当を目視確認予定）

Closes #2