### PR TITLE
ガイドライン更新: PRクローズキーワードとブランチ掃除

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@
 
 ## Commit & Pull Request Guidelines
 - 作業を始めるときは必ず main から作業ブランチを切る（例: `git checkout -b feature/responsive`）；直接 main にはコミットしない。
+- PR本文に `Closes #<issue番号>` などのクローズキーワードを必ず含め、マージ時に対応Issueが自動で閉じるようにする。
 - Commit messages: clear, imperative verbs (e.g., `Tighten input validation`); no strict convention detected.
 - PRs: include intent, key changes, run steps (`uv run main.py`), and screenshots/gifs for UI tweaks.
 - Link related issues and flag risk areas (probability math, layout changes); note follow-ups explicitly.
+- マージ後は `git fetch -p` で不要なリモートブランチを整理し、必要に応じて `git push origin --delete <branch>` でリモートブランチを削除する。
 
 ## Security & Configuration Tips
 - The app reads `PORT`; default is 8050. Document any new env vars you introduce.


### PR DESCRIPTION
## 概要
- PR作成時にクローズキーワードを必ず入れる運用を明文化。
- マージ後のブランチ整理として `git fetch -p` およびリモートブランチ削除を手順に追記。

## 変更点
- `AGENTS.md`: Commit/PRガイドラインにクローズキーワードとブランチ掃除の手順を追加。

## メモ
- #2 対応の後処理ルールとして整理。
